### PR TITLE
Autohide touch controls

### DIFF
--- a/src/pc/controller/controller_api.c
+++ b/src/pc/controller/controller_api.c
@@ -1,0 +1,15 @@
+#include "controller_api.h"
+#if defined(__ANDROID__)
+    int curInputSource=touchScreen;
+#else
+    int curInputSource=keyboard;
+#endif
+
+
+void set_current_input(int in){
+    curInputSource=in;
+}
+
+int get_current_input(){
+    return curInputSource;
+}

--- a/src/pc/controller/controller_api.h
+++ b/src/pc/controller/controller_api.h
@@ -8,4 +8,16 @@ struct ControllerAPI {
     void (*read)(OSContPad *pad);
 };
 
+enum Input{
+    keyboard,
+    emscriptenKeyboard,
+    sdlGameController,
+    touchScreen,
+    wup,
+    xinput
+};
+
+extern void set_current_input(int in);
+extern int get_current_input();
+
 #endif

--- a/src/pc/controller/controller_sdl.c
+++ b/src/pc/controller/controller_sdl.c
@@ -16,6 +16,13 @@
 static bool init_ok;
 static SDL_GameController *sdl_cntrl;
 
+static int16_t leftx;
+static int16_t lefty;
+static int16_t rightx;
+static int16_t righty;
+static int16_t ltrig;
+static int16_t rtrig;
+
 static void controller_sdl_init(void) {
     if (SDL_Init(SDL_INIT_GAMECONTROLLER) != 0) {
         fprintf(stderr, "SDL init error: %s\n", SDL_GetError());
@@ -49,20 +56,49 @@ static void controller_sdl_read(OSContPad *pad) {
             return;
         }
     }
+    bool inputChanged = false;
 
-    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_START)) pad->button |= START_BUTTON;
-    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_LEFTSHOULDER)) pad->button |= Z_TRIG;
-    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)) pad->button |= R_TRIG;
-    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_A)) pad->button |= A_BUTTON;
-    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_X)) pad->button |= B_BUTTON;
+    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_START)){
+        pad->button |= START_BUTTON;
+        inputChanged = true;
+    } 
+    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_LEFTSHOULDER)){
+        pad->button |= Z_TRIG;
+        inputChanged = true;
+    }
+    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_RIGHTSHOULDER)){
+        pad->button |= R_TRIG;
+        inputChanged = true;
+    } 
+    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_A)){
+        pad->button |= A_BUTTON;
+        inputChanged = true;
+    } 
+    if (SDL_GameControllerGetButton(sdl_cntrl, SDL_CONTROLLER_BUTTON_X)){
+        pad->button |= B_BUTTON;
+        inputChanged = true;
+    }
 
-    int16_t leftx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTX);
-    int16_t lefty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTY);
-    int16_t rightx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTX);
-    int16_t righty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTY);
+    int16_t previousLeftX = leftx;
+    int16_t previousLeftY = lefty;
+    int16_t previousRightX = rightx;
+    int16_t previousRightY = righty;
+    int16_t previousLTrig = ltrig;
+    int16_t previousRTrig = rtrig;
 
-    int16_t ltrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERLEFT);
-    int16_t rtrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
+    leftx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTX);
+    lefty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_LEFTY);
+    rightx = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTX);
+    righty = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_RIGHTY);
+
+    ltrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERLEFT);
+    rtrig = SDL_GameControllerGetAxis(sdl_cntrl, SDL_CONTROLLER_AXIS_TRIGGERRIGHT);
+
+    if(leftx!=previousLeftX||lefty!=previousLeftY||rightx!=previousRightX||righty!=previousRightY||ltrig!=previousLTrig||rtrig!=previousRTrig)
+        inputChanged = true;
+
+    if(inputChanged)
+        set_current_input(sdlGameController);
 
 #ifdef TARGET_WEB
     // Firefox has a bug: https://bugzilla.mozilla.org/show_bug.cgi?id=1606562

--- a/src/pc/controller/controller_touchscreen.c
+++ b/src/pc/controller/controller_touchscreen.c
@@ -55,6 +55,8 @@ static int ControlElementsLength = sizeof(ControlElementsDefault)/sizeof(struct 
                               ((pos.y + size / 2 > CORRECT_TOUCH_Y(event->y)) && (pos.y - size / 2 < CORRECT_TOUCH_Y(event->y))))
 
 void touch_down(struct TouchEvent* event) {
+    set_current_input(touchScreen);
+
     struct Position pos;
     for(int i = 0; i < ControlElementsLength; i++) {
         if (ControlElements[i].touchID == 0) {
@@ -182,6 +184,9 @@ static void DrawSprite(s32 x, s32 y, int scaling) {
 }
 
 void render_touch_controls(void) {
+    if(get_current_input()!=touchScreen)
+        return;
+
     Mtx *mtx;
 
     mtx = alloc_display_list(sizeof(*mtx));


### PR DESCRIPTION
Added a simple possebility to define which input device got used lately.

Any input on the gamepad makes the touchscreen controls automatically disappear. Touch the screen to bring them back again :)